### PR TITLE
add additional store details to index page

### DIFF
--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -2,24 +2,26 @@ class Store
   attr_reader :name,
               :address,
               :open_now,
-              :map,
               :google_rating,
               :operating_hours,
               :google_embed_key,
-              :lat,
-              :lng,
-              :place_id
+              :place_id,
+              :operating_hours,
+              :display_phone
 
   def initialize(params)
     @place_id        = params[:place_id]
     @name            = params[:name]
     @address         = params[:vicinity]
+    @store_details   = store_details(place_id)
     @open_now        = store_status(params[:opening_hours][:open_now]) unless params[:opening_hours].nil?
     @lat             = params[:geometry][:location][:lat]
     @lng             = params[:geometry][:location][:lng]
     @google_rating   = params[:rating]
     @google_embed_key = ENV['google_embed_key']
-    @operating_hours = store_hours(params[:opening_hours])
+    @operating_hours = @store_details[:opening_hours][:weekday_text].join(", \n") unless @store_details[:opening_hours].nil?
+    @display_phone   = @store_details[:formatted_phone_number]
+    @phone           = @store_details[:international_phone_number].gsub(/[^0-9+]/, "")
   end
 
   def self.near_by_stores
@@ -27,6 +29,10 @@ class Store
     stores.map do |store|
       Store.new(store)
     end
+  end
+
+  def store_details(place_id)
+    store_details = GoogleServices.new.store_details(place_id)
   end
 
   def store_status(open_now)

--- a/app/services/google_services.rb
+++ b/app/services/google_services.rb
@@ -2,6 +2,11 @@ class GoogleServices
 
   def find_near_by_stores
     stores_raw = Faraday.get("https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=39.615210,-104.758469&radius=16093.4&type=pet_store&keyword=fish&key=#{ENV['google_key']}")
-    parsed_stores = JSON.parse(stores_raw.body, symbolize_names: true)[:results]
+    JSON.parse(stores_raw.body, symbolize_names: true)[:results]
+  end
+
+  def store_details(place_id)
+    raw_store_details = Faraday.get("https://maps.googleapis.com/maps/api/place/details/json?placeid=#{place_id}&key=#{ENV['google_key']}")
+    JSON.parse(raw_store_details.body, symbolize_names: true)[:result]
   end
 end

--- a/app/views/stores/index.html.erb
+++ b/app/views/stores/index.html.erb
@@ -18,7 +18,7 @@
               <p>Address: <%= store.address %></p>
               <p>Status: <%= store.open_now %></p>
               <p>Google Rating: <%= store.google_rating %></p>
-              <p><%= store.operating_hours %></p>
+              <p><%= store.display_phone %></p>
             </div>
           </div>
           <div class="card-action">

--- a/spec/features/login_logout/guest_can_see_login_with_google_spec.rb
+++ b/spec/features/login_logout/guest_can_see_login_with_google_spec.rb
@@ -5,7 +5,7 @@ describe 'when a guest visits the root page' do
     visit root_path
 
     within('#navbar') do
-      expect(page).to have_content("Sign in with Google")
+      expect(page).to have_button("Sign in with Google")
       expect(page).to_not have_content("logout")
     end
   end

--- a/spec/features/stores/guest_can_visit_stores_index_spec.rb
+++ b/spec/features/stores/guest_can_visit_stores_index_spec.rb
@@ -2,9 +2,10 @@ require 'rails_helper'
 
 describe 'when a guest visits store index' do
   it 'they can see a list of stores and infomration about stores' do
-
+    user = User.new(name: "bob", image_url: "https://pbs.twimg.com/profile_images/2577061185/k5z4q8xqcbwq5zk023v0.png")
+     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
     visit stores_path
-
+save_and_open_page
     within all('#store-info')[0] do
       expect(page).to have_content("Address: 7429 East Iliff Avenue")
     end

--- a/spec/features/stores/guest_can_visit_stores_index_spec.rb
+++ b/spec/features/stores/guest_can_visit_stores_index_spec.rb
@@ -5,7 +5,7 @@ describe 'when a guest visits store index' do
     user = User.new(name: "bob", image_url: "https://pbs.twimg.com/profile_images/2577061185/k5z4q8xqcbwq5zk023v0.png")
      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
     visit stores_path
-save_and_open_page
+
     within all('#store-info')[0] do
       expect(page).to have_content("Address: 7429 East Iliff Avenue")
     end


### PR DESCRIPTION
Did another API call to get phone number and operating hours for stores. We are gonna use these for the Yelp API calls. This is the safest way to call those I believe.