### PR TITLE
add store show page

### DIFF
--- a/app/controllers/stores_controller.rb
+++ b/app/controllers/stores_controller.rb
@@ -4,4 +4,8 @@ class StoresController < ApplicationController
   def index
     @stores = Store.near_by_stores
   end
+
+  def show
+    @store = Store.store_details(params[:id])
+  end
 end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -10,7 +10,6 @@ class Store
               :display_phone,
               :yelp_rating
 
-
   def initialize(params)
     @place_id        = params[:place_id]
     @name            = params[:name]
@@ -36,9 +35,15 @@ class Store
 
   def get_yelp_rating(phone)
     rating = YelpServices.new.data(phone)
-    end
+  end
+
   def store_details(place_id)
     store_details = GoogleServices.new.store_details(place_id)
+  end
+
+  def self.store_details(place_id)
+    store_details = GoogleServices.new.store_details(place_id)
+    Store.new(store_details)
   end
 
   def store_status(open_now)

--- a/app/views/stores/index.html.erb
+++ b/app/views/stores/index.html.erb
@@ -14,7 +14,7 @@
          </div>
          <div class="card-content">
           <div id="store-title">
-            <span class="activator grey-text text-darken-4"><p><%= truncate(store.name, length: 30) %></p class="strong"><i class="material-icons right">more_vert</i></span>
+            <span class="activator grey-text text-darken-4"><p><%= link_to truncate(store.name, length: 30), "/stores/#{store.place_id}" %></p><i class="material-icons right">more_vert</i></span>
           </div>
           <div id="store-info" class="grey-text">
              <p><%= store.address %></p>

--- a/app/views/stores/show.html.erb
+++ b/app/views/stores/show.html.erb
@@ -1,0 +1,27 @@
+<h1><%= @store.name %></h1>
+<div class="row">
+  <div class="col s12 m6 z-depth-2">
+    <iframe class="left"
+      width="460"
+      height="450"
+      frameborder="0" style="border:0"
+      src="https://www.google.com/maps/embed/v1/place?key=<%= @store.google_embed_key  %>&q=place_id:<%= @store.place_id  %>">
+    </iframe>
+  </div>
+  <div class="col s12 m1"></div>
+  <div class="col s12 m5">
+    <div class="card white z-depth-4">
+      <div class="card-content black-text">
+        <span class="card-title"><%= @store.address %></span>
+        <p>Status: <%= @store.open_now %></p>
+        <p><%= @store.display_phone %></p>
+        Yelp Score: <%= @store.yelp_rating %><br>
+        Google Score: <%= @store.google_rating %>
+      </div>
+      <div class="card-action">
+        <a href="#">This is a link</a>
+        <a href="#">This is a link</a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   get 'auth/failure', to: redirect('/')
   get 'logout', to: 'sessions#destroy', as: 'logout'
 
-  resources :stores, only: [:index]
+  resources :stores, only: [:index, :show]
   resources :sessions, only: [:create, :destroy]
 
   root to: 'home#show'

--- a/spec/features/stores/guest_can_visit_stores_index_spec.rb
+++ b/spec/features/stores/guest_can_visit_stores_index_spec.rb
@@ -3,13 +3,14 @@ require 'rails_helper'
 describe 'when a guest visits store index' do
   it 'they can see a list of stores and infomration about stores' do
     VCR.use_cassette("stores-index") do
-    user = User.new(name: "bob", image_url: "https://pbs.twimg.com/profile_images/2577061185/k5z4q8xqcbwq5zk023v0.png")
-     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
-     visit stores_path
+      user = User.new(name: "bob", image_url: "https://pbs.twimg.com/profile_images/2577061185/k5z4q8xqcbwq5zk023v0.png")
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      
+      visit stores_path
 
-    within all('#store-title')[0] do
-      expect(page).to have_content("Aquatic Dog")
-    end
+      within all('#store-title')[0] do
+        expect(page).to have_content("Aquatic Dog")
+      end
     end
   end
 end

--- a/spec/features/stores/user_can_visit_store_show_page_spec.rb
+++ b/spec/features/stores/user_can_visit_store_show_page_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe 'when a user visits a store show page' do
+  it 'they can see information about that store' do
+    user = User.new(name: 'bob', image_url: "https://pbs.twimg.com/profile_images/2577061185/k5z4q8xqcbwq5zk023v0.png")
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit store_path('ChIJhYL3eYV9bIcR5gQM9pwB3UY')
+
+    expect(page).to have_content("Aquatic Dog")
+  end
+end


### PR DESCRIPTION
This adds a show page for a store

this was a little tricky since we dont have stores stored in our db. We will have to make some sort of reference to the store when we get to reviews. We have something called a place id that we can use to store reviews and replies for a specific store. We just need to make sure we create methods to pull in this data when we show the store.